### PR TITLE
Fix all build errors and test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,13 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Lint and format
-        run: bun run check
-
-      - name: Type-check
-        run: bun run typecheck
+      - name: Build (includes lint auto-fix + type-check)
+        run: bun run build
 
       - name: Unit and integration tests
-        run: bun test
+        run: bun run test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Guidelines for AI coding agents working on this repository.
 ### Language & Style
 
 - TypeScript with `strict: true` and `target: ESNext`.
-- Use **Biome** for linting and formatting (not ESLint/Prettier). Run `bun run check` to auto-fix.
+- Use **Biome** for linting and formatting (not ESLint/Prettier). Run `bun run lint` to lint + auto-fix.
 - Indent with **tabs**. Biome enforces this.
 - No unused variables or imports (enforced by Biome as errors).
 - Non-null assertions (`!`) are allowed — common in Chrome extension code.
@@ -81,11 +81,8 @@ vi.mocked(chrome.storage.local.get).mockImplementation((_keys, cb) => {
 | Start dev server | `bun run dev` |
 | Build for production | `bun run build` |
 | Run all tests | `bun run test` |
-| Run integration tests only | `bun run test:integration` |
-| Run tests in watch mode | `bun run test:watch` |
 | Coverage report | `bun run test:coverage` |
-| Lint + format | `bun run check` |
-| Type-check | `bun run typecheck` |
+| Lint + format (auto-fix) | `bun run lint` |
 | E2E tests | `bun run build && bun run test:e2e` |
 
 ## Extension Permissions

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
 [![wakatime](https://wakatime.com/badge/user/a0b906ce-b8e7-4463-8bce-383238df6d4b/project/0aaf5b7a-213d-45ed-b4b2-630ad04b129a.svg)](https://wakatime.com/badge/user/a0b906ce-b8e7-4463-8bce-383238df6d4b/project/0aaf5b7a-213d-45ed-b4b2-630ad04b129a)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/ragaeeb/honey-in-the-well?utm_source=oss&utm_medium=github&utm_campaign=ragaeeb%2Fhoney-in-the-well&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+[![codecov](https://codecov.io/gh/ragaeeb/honey-in-the-well/graph/badge.svg?token=7BXCSPFA7O)](https://codecov.io/gh/ragaeeb/honey-in-the-well)
 
 **Integrity-verified full-page screenshots for the web.** Capture an entire page — just like The Wayback Machine — with cryptographic proof that the content hasn't been tampered with.
 
@@ -76,14 +78,8 @@ Creates a distributable `.zip` in `dist/`.
 ## Testing
 
 ```bash
-# Unit tests only (src/)
+# Unit + integration tests
 bun run test
-
-# Integration tests only (tests/integration/)
-bun run test:integration
-
-# Watch mode
-bun run test:watch
 
 # Coverage report
 bun run test:coverage
@@ -92,20 +88,14 @@ bun run test:coverage
 bun run build && bun run test:e2e
 ```
 
-## Linting & Formatting
+## Linting
 
 ```bash
-# Check and auto-fix
-bun run check
-
-# Lint only
+# Lint + format with auto-fix
 bun run lint
 
-# Format only
-bun run format
-
-# Type-check
-bun run typecheck
+# Build always runs lint + type-check first
+bun run build
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "scripts": {
         "dev": "wxt",
         "build": "bun run lint && tsc --noEmit && wxt build",
+        "format": "biome check --write .",
         "zip": "wxt zip",
-        "lint": "biome check --write .",
+        "lint": "biome check .",
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "honey-in-the-well",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "private": true,
     "type": "module",
     "description": "Full-page screenshot capture with cryptographic integrity verification — a source-of-truth snapshot for the web.",
@@ -33,17 +33,12 @@
     },
     "scripts": {
         "dev": "wxt",
-        "build": "wxt build",
+        "build": "bun run lint && tsc --noEmit && wxt build",
         "zip": "wxt zip",
-        "check": "biome check --write .",
-        "lint": "biome lint .",
-        "format": "biome format --write .",
+        "lint": "biome check --write .",
         "test": "vitest run",
-        "test:integration": "vitest run tests/integration",
-        "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "test:e2e": "playwright test",
-        "typecheck": "tsc --noEmit",
         "postinstall": "wxt prepare"
     },
     "dependencies": {

--- a/src/app.css
+++ b/src/app.css
@@ -1,31 +1,31 @@
 @import "tailwindcss";
 
 @theme {
-	--color-background: oklch(0.99 0.002 90);
-	--color-foreground: oklch(0.18 0.04 60);
-	--color-card: oklch(1 0 0);
-	--color-card-foreground: oklch(0.18 0.04 60);
-	--color-popover: oklch(1 0 0);
-	--color-popover-foreground: oklch(0.18 0.04 60);
-	--color-primary: oklch(0.62 0.19 55);
-	--color-primary-foreground: oklch(0.99 0.002 90);
-	--color-secondary: oklch(0.96 0.02 80);
-	--color-secondary-foreground: oklch(0.28 0.06 55);
-	--color-muted: oklch(0.96 0.01 80);
-	--color-muted-foreground: oklch(0.5 0.04 60);
-	--color-accent: oklch(0.82 0.16 70);
-	--color-accent-foreground: oklch(0.2 0.06 55);
-	--color-destructive: oklch(0.577 0.245 27.325);
-	--color-destructive-foreground: oklch(0.577 0.245 27.325);
-	--color-border: oklch(0.91 0.03 80);
-	--color-input: oklch(0.91 0.03 80);
-	--color-ring: oklch(0.62 0.19 55);
-	--color-success: oklch(0.6 0.2 145);
-	--color-warning: oklch(0.75 0.15 75);
-	--radius-sm: 0.25rem;
-	--radius-md: 0.5rem;
-	--radius-lg: 0.75rem;
-	--radius-xl: 1rem;
+    --color-background: oklch(0.99 0.002 90);
+    --color-foreground: oklch(0.18 0.04 60);
+    --color-card: oklch(1 0 0);
+    --color-card-foreground: oklch(0.18 0.04 60);
+    --color-popover: oklch(1 0 0);
+    --color-popover-foreground: oklch(0.18 0.04 60);
+    --color-primary: oklch(0.62 0.19 55);
+    --color-primary-foreground: oklch(0.99 0.002 90);
+    --color-secondary: oklch(0.96 0.02 80);
+    --color-secondary-foreground: oklch(0.28 0.06 55);
+    --color-muted: oklch(0.96 0.01 80);
+    --color-muted-foreground: oklch(0.5 0.04 60);
+    --color-accent: oklch(0.82 0.16 70);
+    --color-accent-foreground: oklch(0.2 0.06 55);
+    --color-destructive: oklch(0.577 0.245 27.325);
+    --color-destructive-foreground: oklch(0.577 0.245 27.325);
+    --color-border: oklch(0.91 0.03 80);
+    --color-input: oklch(0.91 0.03 80);
+    --color-ring: oklch(0.62 0.19 55);
+    --color-success: oklch(0.6 0.2 145);
+    --color-warning: oklch(0.75 0.15 75);
+    --radius-sm: 0.25rem;
+    --radius-md: 0.5rem;
+    --radius-lg: 0.75rem;
+    --radius-xl: 1rem;
 }
 
 @layer base {

--- a/src/entrypoints/capture.html/App.tsx
+++ b/src/entrypoints/capture.html/App.tsx
@@ -115,10 +115,7 @@ export default function App() {
 
     if (loading) {
         return (
-            <div
-                className="flex items-center justify-center min-h-screen"
-                aria-busy="true"
-            >
+            <div className="flex items-center justify-center min-h-screen" aria-busy="true">
                 <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden />
             </div>
         );

--- a/src/entrypoints/options.html/App.tsx
+++ b/src/entrypoints/options.html/App.tsx
@@ -70,10 +70,7 @@ export default function App() {
 
     if (!settings) {
         return (
-            <div
-                className="max-w-2xl mx-auto p-8 flex items-center gap-2"
-                aria-busy="true"
-            >
+            <div className="max-w-2xl mx-auto p-8 flex items-center gap-2" aria-busy="true">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 <p className="text-muted-foreground">Loading...</p>
             </div>

--- a/src/lib/capture/arrangements.ts
+++ b/src/lib/capture/arrangements.ts
@@ -39,7 +39,7 @@ export type ScrollPosition = {
     scrollX: number;
     scrollY: number;
     clip: ClipRect;
-    capture: ClipRect;
+    capture: ClipRect & { delay?: number; bufferBottom?: number };
     hideElts?: Element[];
     yAdjust?: number;
 };
@@ -58,11 +58,15 @@ export class Arrangements {
     addedHeightChange = false;
     lastPosition: ScrollPosition | null = null;
     dimensions: PageDimensions;
+    origWindowX: number;
+    origWindowY: number;
 
     private docElt = document.documentElement;
     private body = document.body;
 
-    constructor(_origBodyHeightZero: boolean, _origWindowX: number, _origWindowY: number) {
+    constructor(_origBodyHeightZero: boolean, origWindowX: number, origWindowY: number) {
+        this.origWindowX = origWindowX;
+        this.origWindowY = origWindowY;
         this.dimensions = this.getDimensions();
     }
 

--- a/src/lib/capture/orchestrator.test.ts
+++ b/src/lib/capture/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type CaptureOptions, captureFullPage } from './orchestrator';
 
 vi.mock('../utils/image', () => ({
@@ -53,6 +53,7 @@ function makeTab(overrides?: Partial<chrome.tabs.Tab>): chrome.tabs.Tab {
         selected: false,
         discarded: false,
         autoDiscardable: true,
+        frozen: false,
         groupId: -1,
         url: 'https://example.com',
         ...overrides,
@@ -65,9 +66,11 @@ describe('orchestrator', () => {
         vi.clearAllMocks();
         vi.useFakeTimers();
 
-        vi.mocked(chrome.tabs.captureVisibleTab).mockResolvedValue('data:image/png;base64,mockdata');
-        vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
-        vi.mocked(chrome.scripting.executeScript).mockResolvedValue([]);
+        vi.mocked(chrome.tabs.captureVisibleTab as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+            'data:image/png;base64,mockdata',
+        );
+        vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ script: true });
+        vi.mocked(chrome.scripting.executeScript as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
         vi.spyOn(document, 'createElement').mockImplementation((tagName: string, options?: ElementCreationOptions) => {
             if (tagName.toLowerCase() === 'canvas') {
@@ -171,8 +174,8 @@ describe('orchestrator', () => {
 
         it('should use default dimensions for blank page without tab dimensions', async () => {
             const tab = makeTab({ url: '' });
-            delete (tab as Record<string, unknown>).width;
-            delete (tab as Record<string, unknown>).height;
+            delete (tab as unknown as { width?: number }).width;
+            delete (tab as unknown as { height?: number }).height;
 
             const promise = captureFullPage(tab, { imageFormat: 'png' });
             await vi.runAllTimersAsync();
@@ -197,7 +200,9 @@ describe('orchestrator', () => {
             chrome.runtime.onMessage.addListener = vi.fn();
             chrome.runtime.onMessage.removeListener = vi.fn();
 
-            vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
+            vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+                script: true,
+            });
 
             const promise = captureFullPage(tab, { imageFormat: 'png' });
 
@@ -251,7 +256,9 @@ describe('orchestrator', () => {
             chrome.runtime.onMessage.addListener = vi.fn();
             chrome.runtime.onMessage.removeListener = vi.fn();
 
-            vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
+            vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+                script: true,
+            });
 
             const promise = captureFullPage(tab, { imageFormat: 'png' });
             await vi.advanceTimersByTimeAsync(100);
@@ -281,7 +288,9 @@ describe('orchestrator', () => {
 
             chrome.runtime.onMessage.addListener = vi.fn();
             chrome.runtime.onMessage.removeListener = vi.fn();
-            vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
+            vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+                script: true,
+            });
 
             captureFullPage(tab, { imageFormat: 'png' });
             await vi.advanceTimersByTimeAsync(100);
@@ -304,7 +313,9 @@ describe('orchestrator', () => {
 
             chrome.runtime.onMessage.addListener = vi.fn();
             chrome.runtime.onMessage.removeListener = vi.fn();
-            vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
+            vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+                script: true,
+            });
 
             captureFullPage(tab, { imageFormat: 'png' });
             await vi.advanceTimersByTimeAsync(100);
@@ -324,7 +335,9 @@ describe('orchestrator', () => {
 
             chrome.runtime.onMessage.addListener = vi.fn();
             chrome.runtime.onMessage.removeListener = vi.fn();
-            vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ script: true });
+            vi.mocked(chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+                script: true,
+            });
 
             captureFullPage(tab, { imageFormat: 'png' });
             await vi.advanceTimersByTimeAsync(100);

--- a/src/lib/capture/orchestrator.ts
+++ b/src/lib/capture/orchestrator.ts
@@ -16,7 +16,7 @@ let lastCaptureTime = 0;
 
 async function throttledCaptureVisibleTab(
     windowId: number,
-    options: chrome.tabs.CaptureVisibleTabOptions,
+    options: chrome.extensionTypes.ImageDetails,
 ): Promise<string> {
     const elapsed = Date.now() - lastCaptureTime;
     if (elapsed < CAPTURE_INTERVAL_MS) {

--- a/src/lib/capture/scroll-finder.ts
+++ b/src/lib/capture/scroll-finder.ts
@@ -26,14 +26,14 @@ function findByDimension(root: Element, vertical: boolean): ScrollableResult | n
     const viewW = window.innerWidth;
     const viewH = window.innerHeight;
     let maxScroll = 0;
-    let maxElt: Element = root;
+    let maxElt: HTMLElement = root as HTMLElement;
     let maxStyle: CSSStyleDeclaration | null = null;
     let maxBox: ElementBox | null = null;
 
     const search = new SearchNodes(root);
     while (search.hasNext()) {
         let added = false;
-        const node = search.next();
+        const node = search.next() as HTMLElement;
         const visible = vertical ? node.offsetHeight : node.offsetWidth;
         const scrollable = vertical ? node.scrollHeight : node.scrollWidth;
 
@@ -101,7 +101,6 @@ function findByDimension(root: Element, vertical: boolean): ScrollableResult | n
         }
     }
 
-    const _dir = vertical ? 'vertical' : 'horizontal';
     if (maxElt === document.body) {
         return null;
     }

--- a/src/lib/crypto/ecdsa.test.ts
+++ b/src/lib/crypto/ecdsa.test.ts
@@ -72,7 +72,7 @@ describe('ecdsa', () => {
     describe('signData', () => {
         it('should sign data with the private key and return signature buffer', async () => {
             const data = new TextEncoder().encode('hello');
-            const result = await signData(mockPrivateKeyJwk, data);
+            const result = await signData(mockPrivateKeyJwk, data.buffer as ArrayBuffer);
 
             expect(result).toBeInstanceOf(ArrayBuffer);
             expect(new Uint8Array(result)).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
@@ -93,7 +93,7 @@ describe('ecdsa', () => {
         it('should throw on invalid JWK', async () => {
             const data = new TextEncoder().encode('hello');
 
-            await expect(signData({} as JsonWebKey, data)).rejects.toThrow('Invalid JWK');
+            await expect(signData({} as JsonWebKey, data.buffer as ArrayBuffer)).rejects.toThrow('Invalid JWK');
         });
     });
 
@@ -102,7 +102,7 @@ describe('ecdsa', () => {
             const data = new TextEncoder().encode('hello');
             const signature = createMockArrayBuffer([1, 2, 3]);
 
-            const result = await verifySignature(mockPublicKeyJwk, signature, data);
+            const result = await verifySignature(mockPublicKeyJwk, signature, data.buffer as ArrayBuffer);
 
             expect(result).toBe(true);
             expect(crypto.subtle.importKey).toHaveBeenCalledWith(
@@ -125,7 +125,7 @@ describe('ecdsa', () => {
             const data = new TextEncoder().encode('hello');
             const signature = createMockArrayBuffer([1, 2, 3]);
 
-            const result = await verifySignature(mockPublicKeyJwk, signature, data);
+            const result = await verifySignature(mockPublicKeyJwk, signature, data.buffer as ArrayBuffer);
 
             expect(result).toBe(false);
         });
@@ -134,7 +134,9 @@ describe('ecdsa', () => {
             const data = new TextEncoder().encode('hello');
             const signature = createMockArrayBuffer([1, 2, 3]);
 
-            await expect(verifySignature({} as JsonWebKey, signature, data)).rejects.toThrow('Invalid JWK');
+            await expect(verifySignature({} as JsonWebKey, signature, data.buffer as ArrayBuffer)).rejects.toThrow(
+                'Invalid JWK',
+            );
         });
     });
 
@@ -178,7 +180,7 @@ describe('ecdsa', () => {
 
     describe('arrayBufferToBase64', () => {
         it('should convert ArrayBuffer to base64 string', () => {
-            const buffer = new TextEncoder().encode('hello').buffer;
+            const buffer = new TextEncoder().encode('hello').buffer as ArrayBuffer;
 
             const result = arrayBufferToBase64(buffer);
 

--- a/src/lib/crypto/ecdsa.test.ts
+++ b/src/lib/crypto/ecdsa.test.ts
@@ -86,7 +86,7 @@ describe('ecdsa', () => {
             expect(crypto.subtle.sign).toHaveBeenCalledWith(
                 { name: 'ECDSA', hash: 'SHA-256' },
                 expect.anything(),
-                data,
+                data.buffer as ArrayBuffer,
             );
         });
 
@@ -116,7 +116,7 @@ describe('ecdsa', () => {
                 { name: 'ECDSA', hash: 'SHA-256' },
                 expect.anything(),
                 signature,
-                data,
+                data.buffer as ArrayBuffer,
             );
         });
 

--- a/src/lib/crypto/key-store.test.ts
+++ b/src/lib/crypto/key-store.test.ts
@@ -15,7 +15,10 @@ const mockKeyPair = {
 describe('key-store', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        chrome.runtime.lastError = null;
+        Object.defineProperty(chrome.runtime, 'lastError', {
+            configurable: true,
+            value: null,
+        });
 
         vi.mocked(crypto.subtle.generateKey).mockResolvedValue({
             publicKey: {} as CryptoKey,
@@ -87,9 +90,12 @@ describe('key-store', () => {
 
         it('should reject when chrome.storage reports an error', async () => {
             vi.mocked(chrome.storage.local.set).mockImplementation((_items, callback) => {
-                chrome.runtime.lastError = {
-                    message: 'Storage quota exceeded',
-                } as chrome.runtime.LastError;
+                Object.defineProperty(chrome.runtime, 'lastError', {
+                    configurable: true,
+                    value: {
+                        message: 'Storage quota exceeded',
+                    } as chrome.runtime.LastError,
+                });
                 callback?.();
             });
 
@@ -150,7 +156,7 @@ describe('key-store', () => {
                 callback?.();
             });
 
-            const _result = await getOrCreateKeyPair();
+            await getOrCreateKeyPair();
 
             expect(setCalls).toHaveLength(1);
             expect((setCalls[0] as Record<string, unknown>).hitw_ecdsa_keypair).toEqual(mockKeyPair);

--- a/src/lib/crypto/signer.test.ts
+++ b/src/lib/crypto/signer.test.ts
@@ -63,7 +63,7 @@ describe('signer', () => {
             expect(crypto.subtle.sign).toHaveBeenCalledWith(
                 { name: 'ECDSA', hash: 'SHA-256' },
                 expect.anything(),
-                expectedPayload,
+                expectedPayload.buffer as ArrayBuffer,
             );
         });
 

--- a/src/lib/crypto/signer.ts
+++ b/src/lib/crypto/signer.ts
@@ -54,7 +54,7 @@ export async function signCapture(
 ): Promise<SignedCapture> {
     const payload = JSON.stringify(metadata);
     const encoded = new TextEncoder().encode(payload);
-    const signatureBuffer = await signData(privateKeyJwk, encoded);
+    const signatureBuffer = await signData(privateKeyJwk, encoded.buffer as ArrayBuffer);
 
     return {
         metadata,

--- a/src/lib/integrity/integrity-monitor.test.ts
+++ b/src/lib/integrity/integrity-monitor.test.ts
@@ -3,11 +3,15 @@ import { IntegrityMonitor } from './integrity-monitor';
 
 describe('IntegrityMonitor', () => {
     beforeEach(() => {
+        vi.spyOn(console, 'table').mockImplementation(() => {});
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'clear').mockImplementation(() => {});
         vi.mocked(crypto.subtle.digest).mockResolvedValue(new Uint8Array([0xab, 0xcd, 0xef]).buffer);
         document.documentElement.innerHTML = '<html><body><div>Test</div></body></html>';
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         vi.useRealTimers();
     });
 

--- a/src/lib/storage/settings-store.test.ts
+++ b/src/lib/storage/settings-store.test.ts
@@ -6,7 +6,10 @@ const STORAGE_KEY = 'hitw_settings';
 describe('settings-store', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        chrome.runtime.lastError = null;
+        Object.defineProperty(chrome.runtime, 'lastError', {
+            configurable: true,
+            value: null,
+        });
 
         vi.mocked(chrome.storage.local.get).mockImplementation((_keys, cb) => {
             (cb as (result: Record<string, unknown>) => void)({});
@@ -100,7 +103,10 @@ describe('settings-store', () => {
 
         it('should reject when chrome.runtime.lastError is set', async () => {
             vi.mocked(chrome.storage.local.set).mockImplementation((_items, cb) => {
-                chrome.runtime.lastError = { message: 'Storage quota exceeded' };
+                Object.defineProperty(chrome.runtime, 'lastError', {
+                    configurable: true,
+                    value: { message: 'Storage quota exceeded' },
+                });
                 if (cb) {
                     cb();
                 }
@@ -125,7 +131,10 @@ describe('settings-store', () => {
 
         it('should reject when chrome.runtime.lastError is set', async () => {
             vi.mocked(chrome.storage.local.set).mockImplementation((_items, cb) => {
-                chrome.runtime.lastError = { message: 'Storage error' };
+                Object.defineProperty(chrome.runtime, 'lastError', {
+                    configurable: true,
+                    value: { message: 'Storage error' },
+                });
                 if (cb) {
                     cb();
                 }

--- a/src/lib/utils/dom.ts
+++ b/src/lib/utils/dom.ts
@@ -14,7 +14,8 @@ export type ElementBox = {
 function getTransformMatrix(el: HTMLElement): DOMMatrix | WebKitCSSMatrix | undefined {
     if (window.DOMMatrix || window.WebKitCSSMatrix) {
         const style = window.getComputedStyle(el);
-        const transform = style.transform || (style as never).webkitTransform;
+        const transform =
+            style.transform || (style as CSSStyleDeclaration & { webkitTransform?: string }).webkitTransform;
         if (!transform || transform === 'none') {
             return undefined;
         }
@@ -23,7 +24,7 @@ function getTransformMatrix(el: HTMLElement): DOMMatrix | WebKitCSSMatrix | unde
                 return new DOMMatrix(transform);
             }
             if (window.WebKitCSSMatrix) {
-                return new (window.WebKitCSSMatrix as never)(transform);
+                return new (window.WebKitCSSMatrix as { new (value: string): WebKitCSSMatrix })(transform);
             }
         } catch {
             return undefined;
@@ -124,7 +125,6 @@ export class SearchNodes {
     private search: Element[];
     private isBfs: boolean;
     private autoAdd: boolean;
-    private onlyElementNodes: boolean;
     private ignoreNodeNames: Set<string>;
     private ignoreHidden: boolean;
 
@@ -133,7 +133,6 @@ export class SearchNodes {
         const cfg = { ...SEARCH_DEFAULTS, ...opts };
         this.isBfs = cfg.isBfs;
         this.autoAdd = cfg.autoAdd;
-        this.onlyElementNodes = cfg.onlyElementNodes;
         this.ignoreNodeNames = cfg.ignoreNodeNames;
         this.ignoreHidden = cfg.ignoreHidden;
         this.search = this.root ? [this.root] : [];

--- a/src/lib/utils/pdf.test.ts
+++ b/src/lib/utils/pdf.test.ts
@@ -110,7 +110,7 @@ describe('generatePdf', () => {
         const tallImages = [makeImage(595, 400), makeImage(595, 400), makeImage(595, 400)];
         await generatePdf(tallImages, 1, 'a4');
 
-        expect(addPageFn.mock.calls.length).toBeGreaterThanOrEqual(0);
+        expect(addPageFn.mock.calls.length).toBeGreaterThan(0);
     });
 
     it('should not add pages for full format', async () => {

--- a/src/lib/utils/pdf.test.ts
+++ b/src/lib/utils/pdf.test.ts
@@ -101,8 +101,10 @@ describe('generatePdf', () => {
     });
 
     it('should add pages for a4 format when content exceeds page height', async () => {
-        const { __mocks } = await import('jspdf');
-        const { addPageFn } = __mocks as { addPageFn: ReturnType<typeof vi.fn> };
+        const { __mocks } = (await import('jspdf')) as unknown as {
+            __mocks: { addPageFn: ReturnType<typeof vi.fn> };
+        };
+        const { addPageFn } = __mocks;
         addPageFn.mockClear();
 
         const tallImages = [makeImage(595, 400), makeImage(595, 400), makeImage(595, 400)];
@@ -112,8 +114,10 @@ describe('generatePdf', () => {
     });
 
     it('should not add pages for full format', async () => {
-        const { __mocks } = await import('jspdf');
-        const { addPageFn } = __mocks as { addPageFn: ReturnType<typeof vi.fn> };
+        const { __mocks } = (await import('jspdf')) as unknown as {
+            __mocks: { addPageFn: ReturnType<typeof vi.fn> };
+        };
+        const { addPageFn } = __mocks;
         addPageFn.mockClear();
 
         const images = [makeImage(500, 2000), makeImage(500, 2000)];

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -57,8 +57,11 @@ test.describe('Extension E2E', () => {
         const heading = optionsPage.locator('h1');
         await expect(heading).toContainText('Settings');
 
-        const apiInput = optionsPage.locator('#apiEndpoint');
-        await expect(apiInput).toBeVisible();
+        const imageFormatSelect = optionsPage.locator('#imageFormat');
+        await expect(imageFormatSelect).toBeVisible();
+
+        const pdfFormatSelect = optionsPage.locator('#pdfFormat');
+        await expect(pdfFormatSelect).toBeVisible();
 
         const saveButton = optionsPage.locator('button', {
             hasText: 'Save Settings',
@@ -99,8 +102,8 @@ test.describe('Extension E2E', () => {
         await optionsPage.goto(`chrome-extension://${extensionId}/options.html`);
         await optionsPage.waitForLoadState('domcontentloaded');
 
-        const apiInput = optionsPage.locator('#apiEndpoint');
-        await apiInput.fill('https://api.test.example.com');
+        const imageFormatSelect = optionsPage.locator('#imageFormat');
+        await imageFormatSelect.selectOption('jpg');
 
         const saveButton = optionsPage.locator('button', {
             hasText: 'Save Settings',
@@ -109,5 +112,8 @@ test.describe('Extension E2E', () => {
 
         const savedText = optionsPage.locator('text=Saved');
         await expect(savedText).toBeVisible({ timeout: 3000 });
+
+        await optionsPage.reload();
+        await expect(optionsPage.locator('#imageFormat')).toHaveValue('jpg');
     });
 });

--- a/tests/integration/crypto-roundtrip.test.ts
+++ b/tests/integration/crypto-roundtrip.test.ts
@@ -67,7 +67,7 @@ describe('crypto integration - sign and verify round-trip', () => {
 
         const payload = JSON.stringify(metadata);
         const encoded = new TextEncoder().encode(payload);
-        const isValid = await verifySignature(keyPair.publicKey, sigBuffer, encoded);
+        const isValid = await verifySignature(keyPair.publicKey, sigBuffer, encoded.buffer as ArrayBuffer);
         expect(isValid).toBe(true);
     });
 

--- a/tests/integration/settings-flow.test.ts
+++ b/tests/integration/settings-flow.test.ts
@@ -25,7 +25,10 @@ describe('settings integration flow', () => {
         vi.mocked(chrome.storage.local.set).mockImplementation(
             (items: Record<string, unknown>, callback?: () => void) => {
                 Object.assign(storage, items);
-                (chrome.runtime as { lastError: null }).lastError = null;
+                Object.defineProperty(chrome.runtime, 'lastError', {
+                    configurable: true,
+                    value: null,
+                });
                 callback?.();
             },
         );


### PR DESCRIPTION
# GPT Codex 5.3

TypeScript errors are fixed. `bun run typecheck` now passes cleanly.

I fixed:
- `Arrangements` fields/types used by content capture flow:
  - restored `origWindowX` / `origWindowY`
  - made `ScrollPosition.capture` include optional `delay`/`bufferBottom`
- Chrome type mismatch in orchestrator:
  - `CaptureVisibleTabOptions` -> `chrome.extensionTypes.ImageDetails`
- Test typing fixes in orchestrator tests:
  - imported `afterEach`
  - included required `Tab.frozen`
  - corrected `delete` casts
  - casted mocked Chrome APIs where overloads confused `vi.mocked`
- DOM typing issues:
  - removed invalid `never` casts for `webkitTransform`/`WebKitCSSMatrix`
  - removed unused `_dir` and unused class field issues
  - tightened `scroll-finder` element typing
- `ArrayBuffer` vs `Uint8Array` mismatches:
  - updated signer and crypto/integration tests to pass `ArrayBuffer`
- Read-only `chrome.runtime.lastError` in tests:
  - replaced direct assignment with `Object.defineProperty(...)`
- `jspdf` mocked module typing in `pdf.test.ts`:
  - added safe cast around dynamic import to access `__mocks`

Validation:
- `bun run typecheck` passes.

Done.

Changes made:
1. `build` now always runs TS checks first  
- Updated [package.json](package.json)  
- `build` is now: `tsc --noEmit && wxt build`  
- Removed standalone `typecheck` script

2. CI updated to stop calling removed script  
- Updated [ci.yml](.github/workflows/ci.yml)  
- Replaced `bun run typecheck` step with `bun run build` (which now includes type-check)

3. Fixed flaky E2E tests  
- Updated [extension.spec.ts](tests/e2e/extension.spec.ts)  
- Root cause: tests were targeting `#apiEndpoint`, which no longer exists in options UI
- Replaced with stable, real selectors:
  - `#imageFormat`
  - `#pdfFormat`
- Save/load test now changes `#imageFormat` to `jpg`, clicks save, reloads page, and verifies persisted value (`toHaveValue('jpg')`)

Validation:
- `bun run build` passes (includes `tsc --noEmit`)

Done.

Updates:
1. `build` now enforces lint + TS checks before building  
- [package.json](package.json)  
- `build` is now:
`bun run check && tsc --noEmit && wxt build`

2. Consolidated integration testing into main test script  
- Removed `test:integration` script from [package.json](package.json)  
- `test` already runs both unit + integration because your [vitest.config.ts](vitest.config.ts) includes:
`src/**/*.test.{ts,tsx}` and `tests/integration/**/*.test.ts`

3. Updated CI to match  
- [ci.yml](.github/workflows/ci.yml)
- Removed separate `check` step
- `bun run build` now gates on lint + typecheck
- Test step still runs full suite (`bun run test:coverage`), which includes unit + integration

Simplified and aligned everything.

What changed:

1. Single lint command (auto-fix)  
- [package.json](package.json)
- `lint` now runs: `biome check --write .`
- Removed `check` and `format` scripts

2. Build now always enforces lint + typecheck  
- [package.json](package.json)
- `build` now runs: `bun run lint && tsc --noEmit && wxt build`

3. CI updated to use the new flow  
- [ci.yml](.github/workflows/ci.yml)
- Build step label updated to reflect `lint auto-fix + type-check`
- Uses `bun run build` (so lint/typecheck always gate build)

4. Docs updated to remove old script references  
- [README.md](README.md)
  - Removed references to `check`, `format`, `typecheck`, `test:integration`, `test:watch`
  - Documented `bun run lint` and `bun run build` behavior
- [AGENTS.md](AGENTS.md)
  - Updated Biome instruction to `bun run lint`
  - Updated common tasks table accordingly

Validation:
- `bun run lint` passes
- `bun run build` passes (and now runs lint + TS checks first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now runs a combined build and coverage workflow and uploads coverage to Codecov.

* **Chores**
  * Bumped release version to 1.0.0.
  * Simplified build/test scripts and consolidated linting into an auto-fix lint command.
  * Updated README and documentation and added badges for PR reviews and Codecov.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->